### PR TITLE
Add rules YAML directive

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -26,8 +26,11 @@ spec:
       initContainers:
         - name: volume-mount-hack
           image: busybox
-          command: ["sh", "-c", "chmod -R 777 /opt/elastalert/rules; chmod -R 777 /opt/elastalert/rule_templates"]
+          command: ["sh", "-c", "cp /opt/elastalert/ruleset/* /opt/elastalert/rules/; chmod -R 777 /opt/elastalert/rules; chmod -R 777 /opt/elastalert/rule_templates;"]
           volumeMounts:
+          - name: rules
+            mountPath: '/opt/elastalert/ruleset'
+            # subPath: ruleset
           - name: data
             mountPath: '/opt/elastalert/rules'
             subPath: rules
@@ -109,3 +112,12 @@ spec:
             items:
             - key: elastalert_api_config
               path: config.json
+        - name: rules
+          configMap:
+            name: {{ template "elastalert.fullname" . }}-rules
+            items:
+{{- range $key, $value := .Values.rules }}
+            - key: {{ $key }}
+              path: {{ $key }}.yaml
+              mode: 0777
+{{- end }}

--- a/templates/rules.yaml
+++ b/templates/rules.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "elastalert.fullname" . }}-rules
+  labels:
+    app: {{ template "elastalert.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  # Additional Rules provided by '.Values.rules'    
+{{- range $key, $value := .Values.rules }}
+{{ $key | indent 2}}: |-
+{{ $value | indent 4}}
+{{- end }}


### PR DESCRIPTION
This commit adds the `rules` YAML directive in the Helm Chart.
It is used similarly to `stable/elastalert` [ 1 ]

Specifically, the `rules` directive expects a map of <name, rule yaml>
and copies the rules as files to a Kubernetes ConfigMap with the
`yaml` file extension.

Finally, it uses the already there `volume-mount-hack` initContainer
to copy the rule files to the `/opt/elastalert/rules` directory
of the Pod (under `data` volumeMount) and grants RW permissions to
`elasticsearch-server`.

Related Issue [ 2 ]


[1] :https://github.com/helm/charts/tree/master/stable/elastalert
[2] :https://github.com/daichi703n/praeco-helm/issues/4