### PR TITLE
Metrics Support + Image Upgrade

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -68,6 +68,11 @@ spec:
             - name: ws
               containerPort: 3333
               protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: 9979
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
       targetPort: metrics
       protocol: TCP
       name: metrics
-    {{- end}}
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "elastalert.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -15,6 +15,12 @@ spec:
       targetPort: ws
       protocol: TCP
       name: ws
+    {{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.port | default 9979 }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end}}
   selector:
     app.kubernetes.io/name: {{ include "elastalert.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: praecoapp/elastalert-server
-  tag: 20230219
+  tag: "20230219" # use quotes if tag contains no string
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/values.yaml
+++ b/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image:
-  repository: daichi703n/elastalert
-  tag: 0.2.1-dev
+  repository: praecoapp/elastalert-server
+  tag: 20230219
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -134,3 +134,7 @@ realertIntervalMins: ""
 #
 # CAUTION: It is recommended to set this to `elastalert` for ES6+. Otherwise elastalert produces confusing index names due to https://github.com/Yelp/elastalert/issues/1479#issuecomment-356380179
 writebackIndex: elastalert_status
+
+metrics:
+  enabled: false
+  port: 9979


### PR DESCRIPTION
### What it brings to the table : 
Existing latest image of praeco/elastalert-server has capability to expose metrics on a port, unfortunately this helm chart is quite outdated and does not support that. We can leverage that to setup some interesting alerts based on those metrics. 

I have enabled that support in this helm chart by adding that port in service and deployment.
It is totally optional and you can render this change in your env with the help of a flag in `values.yaml` file.
e.g.
```
metrics:
  enabled: true
  port: 9979
```

default port is 9979 of the container and for the service you can override that using above config.

### Todo:
1. ServiceMonitor
2. Prometheus Rule
3. README 