### PR TITLE
Adds Support for ServiceMonitor

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "20230219"
 description: ElastAlert Helm chart for Kubernetes
 name: elastalert
-version: 0.1.4
+version: 0.1.5

--- a/commands/install.sh
+++ b/commands/install.sh
@@ -1,1 +1,1 @@
-helm install --name elastalert --namespace elastic elastalert-0.1.4.tgz
+helm install --name elastalert --namespace elastic elastalert-0.1.5.tgz

--- a/commands/upgrade.sh
+++ b/commands/upgrade.sh
@@ -1,1 +1,1 @@
-helm upgrade --recreate-pods -f vars.yml --install elastalert --namespace elastic elastalert-0.1.4.tgz
+helm upgrade --recreate-pods -f vars.yml --install elastalert --namespace elastic elastalert-0.1.5.tgz

--- a/templates/serviceMonitor.yaml
+++ b/templates/serviceMonitor.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: "monitoring.coreos.com/v1"
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- include "elastalert.labels" . | nindent 4 }}
+{{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+{{- end }}
+  name: {{ include "elastalert.fullname" . }}-metrics
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace | quote }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "elastalert.labels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.metrics.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+    {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -20,10 +20,12 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -41,7 +43,8 @@ service_ws:
 
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -53,7 +56,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -136,5 +140,13 @@ realertIntervalMins: ""
 writebackIndex: elastalert_status
 
 metrics:
-  enabled: false
+  enabled: true
   port: 9979
+  serviceMonitor:
+    enabled: true
+    namespace: prometheus
+    interval: 15s
+    scrapeTimeout: 1m
+    scheme: http
+  prometheusRule:
+    enabled: true


### PR DESCRIPTION
Once enabled you can create dashboards/alerts, prom rules, etc. of your choice to be better at monitoring your ElastAlert stack. 
Cheers! 🥂